### PR TITLE
Fix wrong payload object names for conditional close optionals in add_order()...

### DIFF
--- a/kraky/ws.py
+++ b/kraky/ws.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import socket
+from re import sub
 from typing import Callable
 
 import websockets
@@ -221,7 +222,7 @@ class KrakyWsClient:
     ) -> None:
         """https://docs.kraken.com/websockets/#message-addOrder"""
         data = {
-            arg: value
+            sub("^close_(\w+)", r"close[\1]", arg): value
             for arg, value in locals().items()
             if arg != "self" and arg != "connection_name" and value is not None
         }


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

The current add_order() function in the WebSocket class transmits the wrong names for _ordertype_, _price_ and _price2_ for the corresponding (optional) conditional close arguments. The function takes the named optional arguments _close_ordertype_, _close_price_, _close_price2_ and (consistent with how this is handled in similar convenience-functions) directly maps those arguments to a dictionary, which is then passed to the WebSocket connection.

However, the Kraken WebSocket API [expects](https://docs.kraken.com/websockets/#message-addOrder) these exact parameters to be named _close[ordertype]_, _close[price]_ and _close[price]_ (the square brackets are actually part of the literal name). Thus, using the current _add_order()_ implementation with _close_X_ arguments, WS-APIs answer will be an error, due to unknown argument types. 

Because these argument names are directly mapped to the resulting dictionary keys (and square brackets are not allowed in argument names) I solved this by an inline-replacement based on a regular expression, matching on the _close__ prefix followed by a single word group, backreferenced for subsequent replacement. As this does happen inline directly on the argument names (keys), no user-provided input is affected/transformed. 

Feel free to close/transfer this to an issue if you want to fix this differently, I just thought I'll directly show my quick-fix as a PR because I needed to implement it anyways, as the current state (actually I'm on latest stable but I glimpsed through later commits and didn't see anything related to this) is unusable with regard to conditional-close orders.