### PR TITLE
Add KrakenApiAsyncClient to module-level init imports.

### DIFF
--- a/kraky/__init__.py
+++ b/kraky/__init__.py
@@ -1,3 +1,4 @@
 """Kraky main module"""
 from .api import KrakyApiClient
+from .api import KrakyApiAsyncClient
 from .ws import KrakyWsClient


### PR DESCRIPTION
Signed-off-by: Dominique Fuchs <32204802+DominiqueFuchs@users.noreply.github.com>

While importing the latest kraky release – installed as package via pipenv – I noticed that the fairly new KrakenApi**Async**Client cannot be found on namespace level. Only KrakyWsClient and KrakiApiClient (sync) were available. Looking at the modules `__init__.py` I realized the latter ones are specifically imported there.

I'm rather inexperienced regarding pythonic/PEP-guided module handling and conventions, but if I understand it correctly, these module-level imports here are done to provide convenient and controlled namespace access. If this is the case, I'd propose to just add the async client to the list of imports, too. Otherwise, when using kraky as a package, this can be confusing and one has to fall back to mixed  file-level import if the async client shall be used.